### PR TITLE
fix: factory synchronous resubscription (liftEffects)

### DIFF
--- a/src/state/stateFactory.ts
+++ b/src/state/stateFactory.ts
@@ -33,10 +33,7 @@ export default function connectFactoryObservable<A extends [], O>(
     }
 
     const sharedObservable$ = new StateObservable(
-      // This defer breaks it. getObservable(...input) would work
-      new Observable<O>((observer) =>
-        getObservable(...input).subscribe(observer),
-      ),
+      getObservable(...input),
       getDefaultValue(...input),
       () => {
         cache.delete(keys)

--- a/src/state/stateFactory.ts
+++ b/src/state/stateFactory.ts
@@ -33,6 +33,7 @@ export default function connectFactoryObservable<A extends [], O>(
     }
 
     const sharedObservable$ = new StateObservable(
+      // This defer breaks it. getObservable(...input) would work
       new Observable<O>((observer) =>
         getObservable(...input).subscribe(observer),
       ),


### PR DESCRIPTION
I think we need this test working for `liftEffects` to work correctly with state factories.

Otherwise when `liftEffects` resubscribes to its source, it will actually resubscribe to a new instance of the observable, which has a different "sinkEffects" than the one that raised the effect. It's similar to the problem of doing `defer(() => obs$.pipe(sinkEffects(null)))`

I took a quick look and couldn't find an easy solution. On one hand, it's good that the teardown function doesn't get called on reentrant resubscription, but on the other hand the observable is deferred to avoid call stack overflows on factories that have circular references.