### PR TITLE
fix: re-entrant getValue call after Promise

### DIFF
--- a/src/internal/state-observable.ts
+++ b/src/internal/state-observable.ts
@@ -58,11 +58,11 @@ export default class StateObservable<T> extends Observable<T> {
         this.subscription = null
         this.subscription = new Subscriber<T>({
           next: (value: T) => {
-            this.subject!.next((this.currentValue = value))
             if (this.promise && (value as any) !== SUSPENSE) {
               this.promise.res(value as any)
               this.promise = null
             }
+            this.subject!.next((this.currentValue = value))
           },
           error: (err: any) => {
             this.subscription = null

--- a/src/state/stateSingle.test.ts
+++ b/src/state/stateSingle.test.ts
@@ -583,6 +583,33 @@ describe("stateSingle", () => {
         sub.unsubscribe()
       })
     })
+
+    it("allows consumers of the StateObservable to consume getValue synchronously after emitting, when a previouse Promise was created", () => {
+      const source = new Subject<number>()
+      const sourceState = state(source)
+
+      let value = 0
+      let error: any = null
+      sourceState
+        .pipe(
+          map((x) => x + (sourceState.getValue() as number)),
+          take(1),
+        )
+        .subscribe({
+          next(v) {
+            value = v
+          },
+          error(e) {
+            error = e
+          },
+        })
+
+      sourceState.getValue()
+      source.next(3)
+
+      expect(error).toBe(null)
+      expect(value).toBe(6)
+    })
   })
 
   describe("getDefaultValue", () => {


### PR DESCRIPTION
This PR adds a new test (which is currently failing) and its corresponding fix.